### PR TITLE
Refine REGEX for email validation

### DIFF
--- a/core/src/main/java/com/google/zxing/client/result/EmailDoCoMoResultParser.java
+++ b/core/src/main/java/com/google/zxing/client/result/EmailDoCoMoResultParser.java
@@ -29,7 +29,9 @@ import java.util.regex.Pattern;
  */
 public final class EmailDoCoMoResultParser extends AbstractDoCoMoResultParser {
 
-  private static final Pattern EMAIL = Pattern.compile("^[^:]+@([0-9a-zA-Z\\\\-]+\\.)+[0-9a-zA-Z\\\\-]{2,}$");
+  private static final String EMAIL_LOCAL = "[^:]+";
+  private static final String EMAIL_DOMAIN = "([0-9a-zA-Z]+[0-9a-zA-Z\\-]+[0-9a-zA-Z]+\\.)+[a-zA-Z]{2,}";
+  private static final Pattern EMAIL = Pattern.compile("^" + EMAIL_LOCAL + "@" + EMAIL_DOMAIN + "$");
   
   @Override
   public EmailAddressParsedResult parse(Result result) {

--- a/core/src/test/java/com/google/zxing/client/result/EmailAddressParsedResultTestCase.java
+++ b/core/src/test/java/com/google/zxing/client/result/EmailAddressParsedResultTestCase.java
@@ -35,14 +35,21 @@ public final class EmailAddressParsedResultTestCase extends Assert {
     assertFalse(EmailDoCoMoResultParser.isBasicallyValidEmailAddress("123.365.com"));
     assertFalse(EmailDoCoMoResultParser.isBasicallyValidEmailAddress("abc.def.com"));
     assertFalse(EmailDoCoMoResultParser.isBasicallyValidEmailAddress("123@abcd.c"));
+    assertFalse(EmailDoCoMoResultParser.isBasicallyValidEmailAddress("123@abcd"));
     assertFalse(EmailDoCoMoResultParser.isBasicallyValidEmailAddress("123@ab,cd.com"));
     assertFalse(EmailDoCoMoResultParser.isBasicallyValidEmailAddress("123@ab#cd.com"));
     assertFalse(EmailDoCoMoResultParser.isBasicallyValidEmailAddress("123@ab!#cd.com"));
     assertFalse(EmailDoCoMoResultParser.isBasicallyValidEmailAddress("123@ab_cd.com"));
+    assertFalse(EmailDoCoMoResultParser.isBasicallyValidEmailAddress("123@-abcd.com"));
+    assertFalse(EmailDoCoMoResultParser.isBasicallyValidEmailAddress("123@abcd-.com"));
+    assertFalse(EmailDoCoMoResultParser.isBasicallyValidEmailAddress("123@abcd.c-m"));
     assertTrue(EmailDoCoMoResultParser.isBasicallyValidEmailAddress("123@abcd.com"));
     assertTrue(EmailDoCoMoResultParser.isBasicallyValidEmailAddress("123@ab-cd.com"));
     assertTrue(EmailDoCoMoResultParser.isBasicallyValidEmailAddress("abc.456@ab-cd.com"));
+    assertTrue(EmailDoCoMoResultParser.isBasicallyValidEmailAddress("abc.456@ab-cd.BB-EZ-12.com"));
     assertTrue(EmailDoCoMoResultParser.isBasicallyValidEmailAddress("建設省.456@ab-cd.com"));
+    assertTrue(EmailDoCoMoResultParser.isBasicallyValidEmailAddress("abc.Z456@ab-Cd9Z.co"));
+    assertTrue(EmailDoCoMoResultParser.isBasicallyValidEmailAddress("建設省.aZ456@Ab-cd9Z.co"));
   }
 
   @Test


### PR DESCRIPTION
refine regex for email's domain:
 - [x] only letters in the last part
 - [x] no part starting or ending with a dash (dash allowed inside the part)

add UT to cover such cases