### PR TITLE
Throw a more explicit exception when trying to PDF417/TEXT encode something outside of 0...255

### DIFF
--- a/core/src/main/java/com/google/zxing/pdf417/encoder/PDF417HighLevelEncoder.java
+++ b/core/src/main/java/com/google/zxing/pdf417/encoder/PDF417HighLevelEncoder.java
@@ -174,6 +174,16 @@ final class PDF417HighLevelEncoder {
     if (msg.isEmpty()) {
       throw new WriterException("Empty message not allowed");
     }
+    
+    if (Compaction.TEXT == compaction) {
+      for (int i = 0; i < msg.length(); i++) {
+        if (msg.charAt(i) > 255) {
+          throw new WriterException("Non-encodable character detected: " + msg.charAt(i) + " (Unicode: " +
+            (int) msg.charAt(i) +
+            "). Consider specifying Compaction.AUTO instead of Compaction.TEXT");
+        }
+      }
+    }
 
     if (encoding == null && !autoECI) {
       for (int i = 0; i < msg.length(); i++) {


### PR DESCRIPTION
- [x] check if compaction==TEXT and one character is outside of 0...255
- [x] in this case, throw a Writer exception instructing to use Compaction.AUTO instead of Compaction.TEXT
- [x] add UT to cover this use case

Fixes #1761 